### PR TITLE
fix: progressCircle, animDict, and revert notify

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -11,49 +11,46 @@ local function DeleteBlip()
 end
 
 local function pickProcess()
-	if lib.progressCircle({label = Lang:t("progress.pick_grapes"), duration = math.random(6000,8000), canCancel = true, disable = {
-		disableMovement = true,
-		disableCarMovement = true,
-		disableMouse = false,
-		disableCombat = true,
-	},}
-	) then
+	if lib.progressCircle({
+		duration = math.random(6000, 8000),
+		label = Lang:t('progress.pick_grapes'),
+		useWhileDead = false,
+		canCancel = true,
+		disable = {
+			move = true,
+			car = true,
+			mouse = false,
+			combat = true
+		}
+	}) then
 		tasking = false
         TriggerServerEvent("qb-vineyard:server:getGrapes")
 		DeleteBlip()
 	else
-		lib.notify({description= {Lang:t("task.cancel_task")}, type = "error"})
+		QBCore.Functions.Notify(Lang:t('task.cancel_task'), 'error')
 	end
 	ClearPedTasks(cache.ped)
 end
 
-local function LoadAnim(dict)
-    while not HasAnimDictLoaded(dict) do
-        RequestAnimDict(dict)
-        Wait(1)
-    end
-end
-
 local function PickAnim()
-    local ped = cache.ped
-    LoadAnim('amb@prop_human_bum_bin@idle_a')
-    TaskPlayAnim(ped, 'amb@prop_human_bum_bin@idle_a', 'idle_a', 6.0, -6.0, -1, 47, 0, 0, 0, 0)
+    lib.requestAnimDict('amb@prop_human_bum_bin@idle_a')
+    TaskPlayAnim(cache.ped, 'amb@prop_human_bum_bin@idle_a', 'idle_a', 6.0, -6.0, -1, 47, 0, 0, 0, 0)
 end
 
 local function exitZone()
 	if not Config.Debug then return end
-	lib.notify({description = "Zone Exited", type = "inform"})
+	QBCore.Functions.Notify('Zone Exited', 'primary')
 	lib.hideTextUI()
 end
 
 local function enterZone()
 	if not Config.Debug then return end
-	lib.notify({description = "Zone Entered", type = "inform"})
+	QBCore.Functions.Notify('Zone Entered', 'primary')
 end
 
 local function toPickGrapes()
 	lib.showTextUI(Lang:t("task.start_task"), {position = 'right'})
-	if not IsPedInAnyVehicle(cache.ped) and IsControlJustReleased(0,38) then
+	if not IsPedInAnyVehicle(cache.ped) and IsControlJustReleased(0, 38) then
 		PickAnim()
 		pickProcess()
 		lib.hideTextUI()
@@ -77,21 +74,26 @@ end
 
 
 local function PrepareAnim()
-    local ped = cache.ped
-    LoadAnim('amb@code_human_wander_rain@male_a@base')
-    TaskPlayAnim(ped, 'amb@code_human_wander_rain@male_a@base', 'static', 6.0, -6.0, -1, 47, 0, 0, 0, 0)
+    lib.requestAnimDict('amb@code_human_wander_rain@male_a@base')
+    TaskPlayAnim(cache.ped, 'amb@code_human_wander_rain@male_a@base', 'static', 6.0, -6.0, -1, 47, 0, 0, 0, 0)
 end
 
 local function grapeJuiceProcess()
-	if lib.progressCircle({label = Lang:t("progress.process_grapes"), duration = math.random(15000,20000), canCancel = true, disable = {
-		disableMovement = true,
-		disableCarMovement = true,
-		disableMouse = false,
-		disableCombat = true,
-	},}) then
+	if lib.progressCircle({
+		duration = math.random(15000, 20000),
+		label = Lang:t('progress.process_grapes'),
+		useWhileDead = false,
+		canCancel = true,
+		disable = {
+			move = true,
+			car = true,
+			mouse = false,
+			combat = true
+		}
+	}) then
 		TriggerServerEvent("qb-vineyard:server:receiveGrapeJuice")
 	else
-		lib.notify({description= {Lang:t("task.cancel_task")}, type = "error"})
+		QBCore.Functions.Notify(Lang:t('task.cancel_task'), 'error')
 	end
 	ClearPedTasks(cache.ped)
 end
@@ -116,7 +118,7 @@ local function workWine()
 			TriggerServerEvent("qb-vineyard:server:receiveWine")
 			finishedWine = false
 			loadIngredients = false
-			wineStarted = false
+		    wineStarted = false
 		end
 		return
 	end
@@ -132,7 +134,10 @@ end
 local function juiceWork()
 	if IsControlJustReleased(0, 38) then
 		lib.callback('qb-vineyard:server:grapeJuice', false, function(result)
-			if result then PrepareAnim() grapeJuiceProcess() end
+			if result then
+                PrepareAnim()
+                grapeJuiceProcess()
+            end
 		end)
 		return false
 	end

--- a/server.lua
+++ b/server.lua
@@ -9,11 +9,11 @@ local function loadIngredients(item, requirement)
 	local Player = QBCore.Functions.GetPlayer(src)
     local itemCount = exports.ox_inventory:GetItem(src, item, nil, true)
 	if not Player.PlayerData.items then
-        TriggerClientEvent('ox_lib:notify', source, {type = 'error', description = Lang:t("error.no_items")})
+        TriggerClientEvent('QBCore:Notify', src, Lang:t('error.no_items'), 'error')
         return false
     end
     if itemCount < requirement then
-        TriggerClientEvent('ox_lib:notify', source, {type = 'error', description = Lang:t("error.invalid_items")})
+        TriggerClientEvent('QBCore:Notify', src, Lang:t('error.invalid_items'), 'error')
         return false
     end
     Player.Functions.RemoveItem(item, requirement, false)

--- a/server.lua
+++ b/server.lua
@@ -6,9 +6,9 @@ local picked = {}
 ---@return boolean callback The value sent back to the client
 local function loadIngredients(item, requirement)
     local src = source
-	local Player = QBCore.Functions.GetPlayer(src)
+	local player = QBCore.Functions.GetPlayer(src)
     local itemCount = exports.ox_inventory:GetItem(src, item, nil, true)
-	if not Player.PlayerData.items then
+	if not player.PlayerData.items then
         TriggerClientEvent('QBCore:Notify', src, Lang:t('error.no_items'), 'error')
         return false
     end
@@ -16,7 +16,7 @@ local function loadIngredients(item, requirement)
         TriggerClientEvent('QBCore:Notify', src, Lang:t('error.invalid_items'), 'error')
         return false
     end
-    Player.Functions.RemoveItem(item, requirement, false)
+    player.Functions.RemoveItem(item, requirement, false)
     return true
 end
 
@@ -33,8 +33,8 @@ end
 ---@param amount integer Amount of item to be added to inventory
 local function addItem(item, amount)
     if onCooldown(20) then return end
-    local Player = QBCore.Functions.GetPlayer(source)
-    Player.Functions.AddItem(item, amount)
+    local player = QBCore.Functions.GetPlayer(source)
+    player.Functions.AddItem(item, amount)
 end
 
 lib.callback.register('qb-vineyard:server:loadIngredients', function()

--- a/server.lua
+++ b/server.lua
@@ -33,7 +33,7 @@ end
 ---@param amount integer Amount of item to be added to inventory
 local function addItem(item, amount)
     if onCooldown(20) then return end
-    local player = QBCore.Functions.GetPlayer(source)
+    local Player = QBCore.Functions.GetPlayer(source)
     Player.Functions.AddItem(item, amount)
 end
 


### PR DESCRIPTION
## Description

create progressCircle properly, utilize lib.requestAnimDict, fix cache.ped placements, revert notify back to the QB event

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
