### PR TITLE
fix: forgot import.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,6 +5,7 @@ description 'https://github.com/Qbox-project/qbx-vineyard'
 version '1.1.0'
 
 shared_scripts {
+    '@qbx-core/import.lua',
     '@ox_lib/init.lua',
     '@qb-core/shared/locale.lua',
     'locales/en.lua',


### PR DESCRIPTION
## Description

I forgot the import.lua in my previous pr when adding modules

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
