### PR TITLE
fix: loading of the locales and missing phrases

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,12 +3,13 @@ game 'gta5'
 
 description 'QBX_Vineyard'
 repository 'https://github.com/Qbox-project/qbx_vineyard'
-version '1.1.0'
+version '1.0.0'
 
 shared_scripts {
     '@ox_lib/init.lua',
     '@qbx_core/shared/locale.lua',
     'locales/en.lua',
+    'locales/*.lua',
     'config.lua'
 }
 

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -1,29 +1,29 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Nemyslím si, že zde pracuji...",
-        ["invalid_items"] = "Nemáte správné předměty!",
-        ["no_items"] = "Nemáte žádné předměty!",
+        invalid_job = 'Nemyslím si, že zde pracuji...',
+        invalid_items = 'Nemáte správné předměty!',
+        no_items = 'Nemáte žádné předměty!',
     },
     progress = {
-        ["pick_grapes"] = "Sbírání hroznů...",
-        ["process_grapes"] = "Zpracování hroznů...",
+        pick_grapes = 'Sbírání hroznů...',
+        process_grapes = 'Zpracování hroznů...',
     },
     task = {
-        ["start_task"] = "[E] Zahájit",
-        ["load_ingrediants"] = "[E] Načíst ingredience",
-        ["wine_process"] = "[E] Zahájit proces výroby vína",
-        ["get_wine"] = "[E] Získat víno",
-        ["make_grape_juice"] = "[E] Vyrobit hroznový džus",
-        ["countdown"] = "Zbývající čas %{time}s",
-        ['cancel_task'] = "Zrušili jste úkol"
+        start_task = '[E] Zahájit',
+        load_ingrediants = '[E] Načíst ingredience',
+        wine_process = '[E] Zahájit proces výroby vína',
+        get_wine = '[E] Získat víno',
+        make_grape_juice = '[E] Vyrobit hroznový džus',
+        countdown = 'Zbývající čas %{time}s',
+        cancel_task = 'Zrušili jste úkol'
     },
     text = {
-        ["start_shift"] = "Zahájili jste svou směnu ve vinici!",
-        ["end_shift"] = "Vaše směna ve vinici skončila!",
-        ["valid_zone"] = "Platná zóna!",
-        ["invalid_zone"] = "Neplatná zóna!",
-        ["zone_entered"] = "Vstoupil(a) jste do zóny %{zone}",
-        ["zone_exited"] = "Opustil(a) jste zónu %{zone}",
+        start_shift = 'Zahájili jste svou směnu ve vinici!',
+        end_shift = 'Vaše směna ve vinici skončila!',
+        valid_zone = 'Platná zóna!',
+        invalid_zone = 'Neplatná zóna!',
+        zone_entered = 'Vstoupil(a) jste do zóny %{zone}',
+        zone_exited = 'Opustil(a) jste zónu %{zone}',
     }
 }
 
@@ -34,4 +34,3 @@ if GetConvar('qb_locale', 'en') == 'cs' then
         fallbackLang = Lang,
     })
 end
---translate by stepan_valic

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -1,21 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Ich denke ich Arbeite hier nicht...",
-        ["invalid_items"] = "Du hast nicht die korrekten Gegenstände!",
-        ["no_items"] = "Du hast keine Gegenstände!",
+        invalid_job = 'Ich denke ich Arbeite hier nicht...',
+        invalid_items = 'Du hast nicht die korrekten Gegenstände!',
+        no_items = 'Du hast keine Gegenstände!',
     },
     progress = {
-        ["pick_grapes"] = "Sammle Weintrauben ..",
-        ["process_grapes"] = "Verarbeite Weintrauben ..",
+        pick_grapes = 'Sammle Weintrauben ..',
+        process_grapes = 'Verarbeite Weintrauben ..',
     },
     task = {
-        ["start_task"] = "[E] zum Starten",
-        ["load_ingrediants"] = "[E] Zutaten Laden",
-        ["wine_process"] = "[E] Starte den Wein Prozess",
-        ["get_wine"] = "[E] Wein Holen",
-        ["make_grape_juice"] = "[E] Mache Wein Saft",
-        ["countdown"] = "Zeit übrig %{time}",
-        ['cancel_task'] = "Du hast deine Aufgabe Abgebrochen"
+        start_task = '[E] zum Starten',
+        load_ingrediants = '[E] Zutaten Laden',
+        wine_process = '[E] Starte den Wein Prozess',
+        get_wine = '[E] Wein Holen',
+        make_grape_juice = '[E] Mache Wein Saft',
+        countdown = 'Zeit übrig %{time}',
+        cancel_task = 'Du hast deine Aufgabe Abgebrochen'
+    },
+    text = {
+        start_shift = 'You have started your shift at the vineyard!',
+        end_shift = 'Your shift at the vineyard has ended!',
+        valid_zone = 'Valid Zone!',
+        invalid_zone = 'Invalid Zone!',
+        zone_entered = '%{zone} Zone Entered',
+        zone_exited = '%{zone} Zone Exited',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'de' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,29 +1,33 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "I dont think I work here...",
-        ["invalid_items"] = "You do not have the correct items!",
-        ["no_items"] = "You do not have any items!",
+        invalid_job = 'I dont think I work here...',
+        invalid_items = 'You do not have the correct items!',
+        no_items = 'You do not have any items!',
     },
     progress = {
-        ["pick_grapes"] = "Picking Grapes ..",
-        ["process_grapes"] = "Processing Grapes ..",
+        pick_grapes = 'Picking Grapes ..',
+        process_grapes = 'Processing Grapes ..',
     },
     task = {
-        ["start_task"] = "[E] To Start",
-        ["load_ingrediants"] = "[E] Load Ingredients",
-        ["wine_process"] = "[E] Start WineProcess",
-        ["get_wine"] = "[E] Get Wine",
-        ["make_grape_juice"] = "[E] Make Grape Juice",
-        ["countdown"] = "Time Remaining %{time}s",
-        ['cancel_task'] = "You have cancelled the task"
+        start_task = '[E] To Start',
+        load_ingrediants = '[E] Load Ingredients',
+        wine_process = '[E] Start WineProcess',
+        get_wine = '[E] Get Wine',
+        make_grape_juice = '[E] Make Grape Juice',
+        countdown = 'Time Remaining %{time}s',
+        cancel_task = 'You have cancelled the task'
     },
     text = {
-        ["start_shift"] = "You have started your shift at the vineyard!",
-        ["end_shift"] = "Your shift at the vineyard has ended!",
-        ["valid_zone"] = "Valid Zone!",
-        ["invalid_zone"] = "Invalid Zone!",
-        ["zone_entered"] = "%{zone} Zone Entered",
-        ["zone_exited"] = "%{zone} Zone Exited",
+        start_shift = 'You have started your shift at the vineyard!',
+        end_shift = 'Your shift at the vineyard has ended!',
+        valid_zone = 'Valid Zone!',
+        invalid_zone = 'Invalid Zone!',
+        zone_entered = '%{zone} Zone Entered',
+        zone_exited = '%{zone} Zone Exited',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+Lang = Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,29 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "No creo que trabaje aquí...",
-        ["invalid_items"] = "¡No tienes el item correcto!",
-        ["no_items"] = "No tienes ningun item",
+        invalid_job = 'No creo que trabaje aquí...',
+        invalid_items = '¡No tienes el item correcto!',
+        no_items = 'No tienes ningun item',
     },
     progress = {
-        ["pick_grapes"] = "Recogiendo uvas..",
-        ["process_grapes"] = "Procesando uvas.. ..",
+        pick_grapes = 'Recogiendo uvas..',
+        process_grapes = 'Procesando uvas.. ..',
     },
     task = {
-        ["start_task"] = "[E] Para empezar",
-        ["load_ingrediants"] = "[E] Cargar Ingredientes",
-        ["wine_process"] = "[E] Comenzar la elaboracion del vino",
-        ["get_wine"] = "[E] Obtener Vino",
-        ["make_grape_juice"] = "[E] Hacer zumo de uva (Mosto)",
-        ["countdown"] = "Tiempo restante %{time}s",
-        ['cancel_task'] = "Has cancelado la tarea"
+        start_task = '[E] Para empezar',
+        load_ingrediants = '[E] Cargar Ingredientes',
+        wine_process = '[E] Comenzar la elaboracion del vino',
+        get_wine = '[E] Obtener Vino',
+        make_grape_juice = '[E] Hacer zumo de uva (Mosto)',
+        countdown = 'Tiempo restante %{time}s',
+        cancel_task = 'Has cancelado la tarea'
     },
     text = {
-        ["start_shift"] = "¡Has comenzado tu turno en el viñedo!",
-        ["end_shift"] = "¡Has finalizado tu turno en el viñedo!",
-        ["valid_zone"] = "Zona Valida!",
-        ["invalid_zone"] = "Zona NO Valida!",
-        ["zone_entered"] = "%{zone} Entrando en zona",
-        ["zone_exited"] = "%{zone} Saliendo de zona",
+        start_shift = '¡Has comenzado tu turno en el viñedo!',
+        end_shift = '¡Has finalizado tu turno en el viñedo!',
+        valid_zone = 'Zona Valida!',
+        invalid_zone = 'Zona NO Valida!',
+        zone_entered = '%{zone} Entrando en zona',
+        zone_exited = '%{zone} Saliendo de zona',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'es' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/fi.lua
+++ b/locales/fi.lua
@@ -1,21 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Et taida olla töissä täällä...",
-        ["invalid_items"] = "Sinulla ei ole oikeita esineitä!",
-        ["no_items"] = "Sinulla ei ole esineitä!",
+        invalid_job = 'Et taida olla töissä täällä...',
+        invalid_items = 'Sinulla ei ole oikeita esineitä!',
+        no_items = 'Sinulla ei ole esineitä!',
     },
     progress = {
-        ["pick_grapes"] = "Kerätään rypäleitä ..",
-        ["process_grapes"] = "Prosessoidaan rypäleitä ..",
+        pick_grapes = 'Kerätään rypäleitä ..',
+        process_grapes = 'Prosessoidaan rypäleitä ..',
     },
     task = {
-        ["start_task"] = "Paina [E] aloittaaksesi",
-        ["load_ingrediants"] = "[E] Lastaa ainesosat",
-        ["wine_process"] = "[E] Aloita viininteko",
-        ["get_wine"] = "[E] Tee viiniä",
-        ["make_grape_juice"] = "[E] Tee rypälemehua",
-        ["countdown"] = "Aikaa jäljellä %{time}s",
-        ['cancel_task'] = "Olet peruuttanut tehtävän!"
+        start_task = 'Paina [E] aloittaaksesi',
+        load_ingrediants = '[E] Lastaa ainesosat',
+        wine_process = '[E] Aloita viininteko',
+        get_wine = '[E] Tee viiniä',
+        make_grape_juice = '[E] Tee rypälemehua',
+        countdown = 'Aikaa jäljellä %{time}s',
+        cancel_task = 'Olet peruuttanut tehtävän!'
+    },
+    text = {
+        start_shift = 'You have started your shift at the vineyard!',
+        end_shift = 'Your shift at the vineyard has ended!',
+        valid_zone = 'Valid Zone!',
+        invalid_zone = 'Invalid Zone!',
+        zone_entered = '%{zone} Zone Entered',
+        zone_exited = '%{zone} Zone Exited',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'fi' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/ge.lua
+++ b/locales/ge.lua
@@ -1,21 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "არამგონია აქ ვიმუშაო...",
-        ["invalid_items"] = "თქვენ არ გაქვთ სწორი ნივთები!",
-        ["no_items"] = "თქვენ არ გაქვთ რაიმე ნივთი!",
+        invalid_job = 'არამგონია აქ ვიმუშაო...',
+        invalid_items = 'თქვენ არ გაქვთ სწორი ნივთები!',
+        no_items = 'თქვენ არ გაქვთ რაიმე ნივთი!',
     },
     progress = {
-        ["pick_grapes"] = "ყურძნის კრეფა ..",
-        ["process_grapes"] = "ყურძნის გადამუშავება..",
+        pick_grapes = 'ყურძნის კრეფა ..',
+        process_grapes = 'ყურძნის გადამუშავება..',
     },
     task = {
-        ["start_task"] = "[E] Დაწყება",
-        ["load_ingrediants"] = "[E] ჩატვირთეთ ინგრედიენტები",
-        ["wine_process"] = "[E] დაიწყეთ ღვინის პროცესი",
-        ["get_wine"] = "[E] მიიღეთ ღვინო",
-        ["make_grape_juice"] = "[E] მოამზადეთ ყურძნის წვენი",
-        ["countdown"] = "Დარჩენილი დრო %{time}s",
-        ['cancel_task'] = "თქვენ გააუქმეთ დავალება"
+        start_task = '[E] Დაწყება',
+        load_ingrediants = '[E] ჩატვირთეთ ინგრედიენტები',
+        wine_process = '[E] დაიწყეთ ღვინის პროცესი',
+        get_wine = '[E] მიიღეთ ღვინო',
+        make_grape_juice = '[E] მოამზადეთ ყურძნის წვენი',
+        countdown = 'Დარჩენილი დრო %{time}s',
+        cancel_task = 'თქვენ გააუქმეთ დავალება'
+    },
+    text = {
+        start_shift = 'You have started your shift at the vineyard!',
+        end_shift = 'Your shift at the vineyard has ended!',
+        valid_zone = 'Valid Zone!',
+        invalid_zone = 'Invalid Zone!',
+        zone_entered = '%{zone} Zone Entered',
+        zone_exited = '%{zone} Zone Exited',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'ge' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -1,21 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Non penso di lavorare qui...",
-        ["invalid_items"] = "Non hai gli oggetti corretti!",
-        ["no_items"] = "Non hai nessun oggetto!",
+        invalid_job = 'Non penso di lavorare qui...',
+        invalid_items = 'Non hai gli oggetti corretti!',
+        no_items = 'Non hai nessun oggetto!',
     },
     progress = {
-        ["pick_grapes"] = "Raccogliendo l'uva ..",
-        ["process_grapes"] = "Lavorando l'uva ..",
+        pick_grapes = 'Raccogliendo l\'uva ..',
+        process_grapes = 'Lavorando l\'uva ..',
     },
     task = {
-        ["start_task"] = "[E] Per Cominciare",
-        ["load_ingrediants"] = "[E] Inserisci Ingredienti",
-        ["wine_process"] = "[E] Avvia lavorazione vino",
-        ["get_wine"] = "[E] Prendi il vino",
-        ["make_grape_juice"] = "[E] Fai succo d'uva",
-        ["countdown"] = "Tempo rimasto %{time}s",
-        ['cancel_task'] = "Hai cancellato il compito"
+        start_task = '[E] Per Cominciare',
+        load_ingrediants = '[E] Inserisci Ingredienti',
+        wine_process = '[E] Avvia lavorazione vino',
+        get_wine = '[E] Prendi il vino',
+        make_grape_juice = '[E] Fai succo d\'uva',
+        countdown = 'Tempo rimasto %{time}s',
+        cancel_task = 'Hai cancellato il compito'
+    },
+    text = {
+        start_shift = 'You have started your shift at the vineyard!',
+        end_shift = 'Your shift at the vineyard has ended!',
+        valid_zone = 'Valid Zone!',
+        invalid_zone = 'Invalid Zone!',
+        zone_entered = '%{zone} Zone Entered',
+        zone_exited = '%{zone} Zone Exited',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'it' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -1,29 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Ik denk niet dat ik hier werk...",
-        ["invalid_items"] = "Je hebt niet de juiste items!",
-        ["no_items"] = "Je hebt geen items!",
+        invalid_job = 'Ik denk niet dat ik hier werk...',
+        invalid_items = 'Je hebt niet de juiste items!',
+        no_items = 'Je hebt geen items!',
     },
     progress = {
-        ["pick_grapes"] = "Druiven plukken ..",
-        ["process_grapes"] = "Druiven Verwerken ..",
+        pick_grapes = 'Druiven plukken ..',
+        process_grapes = 'Druiven Verwerken ..',
     },
     task = {
-        ["start_task"] = "[E] Beginnen",
-        ["load_ingrediants"] = "[E] Ingrediënten laden",
-        ["wine_process"] = "[E] Wijnproces Starten",
-        ["get_wine"] = "[E] Pak Wijn",
-        ["make_grape_juice"] = "[E] Druivensap maken",
-        ["countdown"] = "Resterende tijd %{time}s",
-        ['cancel_task'] = "Je hebt de taak geannuleerd"
+        start_task = '[E] Beginnen',
+        load_ingrediants = '[E] Ingrediënten laden',
+        wine_process = '[E] Wijnproces Starten',
+        get_wine = '[E] Pak Wijn',
+        make_grape_juice = '[E] Druivensap maken',
+        countdown = 'Resterende tijd %{time}s',
+        cancel_task = 'Je hebt de taak geannuleerd'
     },
     text = {
-        ["start_shift"] = "Je bent begonnen met je dienst in de wijngaard!",
-        ["end_shift"] = "Je dienst bij de wijngaard zit erop!",
-        ["valid_zone"] = "Geldige Zone!",
-        ["invalid_zone"] = "Ongeldige Zone!",
-        ["zone_entered"] = "%{zone} Zone Ingelopen",
-        ["zone_exited"] = "%{zone} Zone Verlaten",
+        start_shift = 'Je bent begonnen met je dienst in de wijngaard!',
+        end_shift = 'Je dienst bij de wijngaard zit erop!',
+        valid_zone = 'Geldige Zone!',
+        invalid_zone = 'Ongeldige Zone!',
+        zone_entered = '%{zone} Zone Ingelopen',
+        zone_exited = '%{zone} Zone Verlaten',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'nl' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -1,29 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Acho que não trabalho aqui..",
-        ["invalid_items"] = "Não tens os items corretos!",
-        ["no_items"] = "Não tens os items necessários!",
+        invalid_job = 'Acho que não trabalho aqui..',
+        invalid_items = 'Não tens os items corretos!',
+        no_items = 'Não tens os items necessários!',
     },
     progress = {
-        ["pick_grapes"] = "A Apanhar Uvas..",
-        ["process_grapes"] = "A Processar Uvas..",
+        pick_grapes = 'A Apanhar Uvas..',
+        process_grapes = 'A Processar Uvas..',
     },
     task = {
-        ["start_task"] = "[E] Para Começar",
-        ["load_ingrediants"] = "[E] Preparar Ingredientes",
-        ["wine_process"] = "[E] Começar Processo Do Vinho",
-        ["get_wine"] = "[E] Obter Vinho",
-        ["make_grape_juice"] = "[E] Fazer Sumo De Uva",
-        ["countdown"] = "Tempo Restante %{time}s",
-        ['cancel_task'] = "Cancelaste a tarefa"
+        start_task = '[E] Para Começar',
+        load_ingrediants = '[E] Preparar Ingredientes',
+        wine_process = '[E] Começar Processo Do Vinho',
+        get_wine = '[E] Obter Vinho',
+        make_grape_juice = '[E] Fazer Sumo De Uva',
+        countdown = 'Tempo Restante %{time}s',
+        cancel_task = 'Cancelaste a tarefa'
     },
     text = {
-        ["start_shift"] = "O teu turno nas vinhas começou!",
-        ["end_shift"] = "O teu turno nas vinhas terminou!",
-        ["valid_zone"] = "Zona Válida!",
-        ["invalid_zone"] = "Zona Inválida!",
-        ["zone_entered"] = "Entraste Na Zona %{zone}",
-        ["zone_exited"] = "Saíste Da Zona %{zone}",
+        start_shift = 'O teu turno nas vinhas começou!',
+        end_shift = 'O teu turno nas vinhas terminou!',
+        valid_zone = 'Zona Válida!',
+        invalid_zone = 'Zona Inválida!',
+        zone_entered = 'Entraste Na Zona %{zone}',
+        zone_exited = 'Saíste Da Zona %{zone}',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'pt' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/sv.lua
+++ b/locales/sv.lua
@@ -1,21 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Jag tror inte att du jobbar här...",
-        ["invalid_items"] = "Du har inte rätt prylar!",
-        ["no_items"] = "Du har inga prylar!",
+        invalid_job = 'Jag tror inte att du jobbar här...',
+        invalid_items = 'Du har inte rätt prylar!',
+        no_items = 'Du har inga prylar!',
     },
     progress = {
-        ["pick_grapes"] = "Plockar vindruvor..",
-        ["process_grapes"] = "Proccesserar vindruvor..",
+        pick_grapes = 'Plockar vindruvor..',
+        process_grapes = 'Proccesserar vindruvor..',
     },
     task = {
-        ["start_task"] = "[E] För att starta",
-        ["load_ingrediants"] = "[E] Blanda i ingredienser",
-        ["wine_process"] = "[E] Starta jäsningsprocessen",
-        ["get_wine"] = "[E] Ta vinet",
-        ["make_grape_juice"] = "[E] Göra druvjuice",
-        ["countdown"] = "Tid kvar: %{time}s",
-        ['cancel_task'] = "Du avbröt en uppgift"
+        start_task = '[E] För att starta',
+        load_ingrediants = '[E] Blanda i ingredienser',
+        wine_process = '[E] Starta jäsningsprocessen',
+        get_wine = '[E] Ta vinet',
+        make_grape_juice = '[E] Göra druvjuice',
+        countdown = 'Tid kvar: %{time}s',
+        cancel_task = 'Du avbröt en uppgift'
+    },
+    text = {
+        start_shift = 'You have started your shift at the vineyard!',
+        end_shift = 'Your shift at the vineyard has ended!',
+        valid_zone = 'Valid Zone!',
+        invalid_zone = 'Invalid Zone!',
+        zone_entered = '%{zone} Zone Entered',
+        zone_exited = '%{zone} Zone Exited',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'sv' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -1,29 +1,36 @@
 local Translations = {
     error = {
-        ["invalid_job"] = "Burada çalıştığımı sanmıyorum...",
-        ["invalid_items"] = "Doğru itemlere sahip değilsin!",
-        ["no_items"] = "Herhangi bir iteminiz yok!",
+        invalid_job = 'Burada çalıştığımı sanmıyorum...',
+        invalid_items = 'Doğru itemlere sahip değilsin!',
+        no_items = 'Herhangi bir iteminiz yok!',
     },
     progress = {
-        ["pick_grapes"] = "Üzüm toplanıyor ..",
-        ["process_grapes"] = "Üzüm İşleniyor ..",
+        pick_grapes = 'Üzüm toplanıyor ..',
+        process_grapes = 'Üzüm İşleniyor ..',
     },
     task = {
-        ["start_task"] = "[E] Başla",
-        ["load_ingrediants"] = "[E] Malzemeleri Yükle",
-        ["wine_process"] = "[E] Şarap İşlemeye Başla",
-        ["get_wine"] = "[E] Şarap Al",
-        ["make_grape_juice"] = "[E] Üzüm Suyu Yap",
-        ["countdown"] = "Kalan süre %{time}s",
-        ['cancel_task'] = "Görevi iptal ettiniz"
+        start_task = '[E] Başla',
+        load_ingrediants = '[E] Malzemeleri Yükle',
+        wine_process = '[E] Şarap İşlemeye Başla',
+        get_wine = '[E] Şarap Al',
+        make_grape_juice = '[E] Üzüm Suyu Yap',
+        countdown = 'Kalan süre %{time}s',
+        cancel_task = 'Görevi iptal ettiniz'
     },
     text = {
-        ["start_shift"] = "Bağda mesaiye başladın!",
-        ["end_shift"] = "Bağdaki vardiyanız sona erdi!",
-        ["valid_zone"] = "Geçerli Bölge!",
-        ["invalid_zone"] = "Geçersiz Bölge!",
-        ["zone_entered"] = "%{zone} Bölgesine Girildi",
-        ["zone_exited"] = "%{zone} Bölgesinden Çıkıldı",
+        start_shift = 'Bağda mesaiye başladın!',
+        end_shift = 'Bağdaki vardiyanız sona erdi!',
+        valid_zone = 'Geçerli Bölge!',
+        invalid_zone = 'Geçersiz Bölge!',
+        zone_entered = '%{zone} Bölgesine Girildi',
+        zone_exited = '%{zone} Bölgesinden Çıkıldı',
     }
 }
-Lang = Locale:new({phrases = Translations, warnOnMissing = true})
+
+if GetConvar('qb_locale', 'en') == 'tr' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end


### PR DESCRIPTION
## Description

1. Fixed loading of the locales
2. Added missing ones

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
